### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,14 +9,12 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "68a7dab72d19d9189a32b540",
+  "nxCloudId": "68b832d6991e79c2aa342fe3",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
       "options": {
-        "typecheck": {
-          "targetName": "typecheck"
-        },
+        "typecheck": { "targetName": "typecheck" },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
@@ -25,27 +23,12 @@
         }
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    }
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } }
   ],
   "release": {
     "projects": ["packages/*"],
-    "changelog": {
-      "workspaceChangelog": false,
-      "projectChangelogs": false
-    },
-    "version": {
-      "conventionalCommits": true
-    },
-    "git": {
-      "stageChanges": true,
-      "commit": true,
-      "tag": true,
-      "push": true
-    }
+    "changelog": { "workspaceChangelog": false, "projectChangelogs": false },
+    "version": { "conventionalCommits": true },
+    "git": { "stageChanges": true, "commit": true, "tag": true, "push": true }
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68b832c9d437128e5451b4de/workspaces/68b832d6991e79c2aa342fe3

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.